### PR TITLE
Fix OpenAI ChatCompletion call

### DIFF
--- a/scripts/codex_controller.py
+++ b/scripts/codex_controller.py
@@ -8,7 +8,7 @@ openai.api_key = os.getenv("OPENAI_API_KEY", "sk-REPLACE_WITH_YOUR_KEY")
 def run_codex_command(prompt: str) -> None:
     """Send the prompt to the model and execute the returned command."""
     try:
-        response = openai.chat.completions.create(
+        response = openai.ChatCompletion.create(
             model="gpt-4",
             messages=[
                 {
@@ -22,7 +22,7 @@ def run_codex_command(prompt: str) -> None:
             ],
         )
 
-        command = response.choices[0].message.content.strip()
+        command = response["choices"][0]["message"]["content"].strip()
         print(f"💡 Codex says: {command}")
         os.system(command)
     except Exception as e:


### PR DESCRIPTION
## Summary
- update `codex_controller.py` to use `openai.ChatCompletion.create`
- update response parsing for v1.x API

## Testing
- `python -m py_compile scripts/codex_controller.py`

------
https://chatgpt.com/codex/tasks/task_e_685dc5b127d083218e2f5fb4703df2ae