### PR TITLE
Improve config defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,17 @@ The project includes an optional Express API located in `src/`. To run it you ne
 The API key is mandatory and the server will refuse to start if `API_KEY` is not provided or uses the insecure default value.
 
 The `EnhancedVideoProcessingSystem` currently stores video statuses in memory only. For production use, connect a persistent store such as Redis or a database and update `videoStatusStore` accordingly.
+
+## Required Environment Variables
+
+Sensitive credentials can be loaded from environment variables or a `config.json` file placed in the project root. Define the following variables:
+
+- `OPENAI_API_KEY`
+- `RUNWAYML_API_KEY`
+- `OPENROUTER_API_KEY`
+- `ELEVENLABS_API_KEY`
+- `ELEVENLABS_VOICE_ID`
+- `GOOGLE_SHEETS_CREDENTIAL_ID`
+- `GOOGLE_SHEETS_ACCOUNT_NAME`
+- `YOUTUBE_CREDENTIAL_ID`
+- `YOUTUBE_ACCOUNT_NAME`


### PR DESCRIPTION
## Summary
- allow ConfigManager to load sensitive keys from a config.json file
- fall back to `null` when values are missing and warn
- document required environment variables

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867505c6034832192b80602bdd8dacf