### PR TITLE
Improve EnhancedEventBus metadata handling

### DIFF
--- a/src/enhancedVideoProcessingSystem.js
+++ b/src/enhancedVideoProcessingSystem.js
@@ -53,11 +53,13 @@ class EnhancedVideoProcessingSystem extends VideoProcessingSystem {
   }
 
   setupMonitoring() {
-    this.eventBus.subscribe('message.dead_letter', ({ message }) => {
+    this.eventBus.subscribe('message.dead_letter', ({ data }) => {
+      const { message } = data;
       this.logger.error('Message to dead letter', { id: message.id, type: message.type });
       this.metrics.increment('dead_letter_queue.messages');
     });
-    this.eventBus.subscribe('health.check.completed', ({ status }) => {
+    this.eventBus.subscribe('health.check.completed', ({ data }) => {
+      const { status } = data;
       this.metrics.increment('health_check.completed', { status });
       if (status === 'unhealthy') {
         this.logger.warn('System health check failed');


### PR DESCRIPTION
## Summary
- include a `generateId` helper on the base `EventBus`
- pass event metadata to handlers via `executeHandler`
- emit `message.dead_letter` through the enhanced bus
- update monitoring handlers for the new message format

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68675061f88883219544b3ce8cab1a50