### PR TITLE
Add configurable cleanup interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,5 @@ The project includes an optional Express API located in `src/`. To run it you ne
 The API key is mandatory and the server will refuse to start if `API_KEY` is not provided or uses the insecure default value.
 
 The `EnhancedVideoProcessingSystem` currently stores video statuses in memory only. For production use, connect a persistent store such as Redis or a database and update `videoStatusStore` accordingly.
+
+The built-in rate limiter also keeps request timestamps in memory for each user. If your API receives traffic from many unique users this map can grow large. Adjust `rate.limit.cleanupInterval` via the `/config` endpoint to prune inactive keys more often or consider an external store when scaling.

--- a/src/configManager.js
+++ b/src/configManager.js
@@ -16,6 +16,7 @@ class ConfigManager {
     this.config.set('circuit.breaker.threshold', 5);
     this.config.set('rate.limit.requests', 100);
     this.config.set('rate.limit.window', 60000);
+    this.config.set('rate.limit.cleanupInterval', 10000);
     this.config.set('health.check.interval', 30000);
 
     this.loadEnv('openai.apiKey');

--- a/src/enhancedVideoProcessingSystem.js
+++ b/src/enhancedVideoProcessingSystem.js
@@ -14,7 +14,8 @@ class EnhancedVideoProcessingSystem extends VideoProcessingSystem {
     this.configManager = new ConfigManager();
     this.rateLimiter = new RateLimiter(
       this.configManager.get('rate.limit.requests'),
-      this.configManager.get('rate.limit.window')
+      this.configManager.get('rate.limit.window'),
+      this.configManager.get('rate.limit.cleanupInterval')
     );
     this.cache = {};
     this.circuitBreaker = { state: 'CLOSED', failureCount: 0 };


### PR DESCRIPTION
## Summary
- expose `rate.limit.cleanupInterval` in ConfigManager
- pass cleanup interval to `RateLimiter`
- document rate limiter memory usage and tuning

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686750680c7c8321a56236acf775c708