### PR TITLE
Add Jest tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,13 @@ The project includes an optional Express API located in `src/`. To run it you ne
 The API key is mandatory and the server will refuse to start if `API_KEY` is not provided or uses the insecure default value.
 
 The `EnhancedVideoProcessingSystem` currently stores video statuses in memory only. For production use, connect a persistent store such as Redis or a database and update `videoStatusStore` accordingly.
+
+## Running Tests
+
+Unit tests use [Jest](https://jestjs.io/). After installing dependencies you can execute:
+
+```bash
+npm test
+```
+
+This runs the test suite located in `__tests__/` covering the enhanced event bus, rate limiter and API endpoint logic.

--- a/README.md
+++ b/README.md
@@ -83,3 +83,17 @@ npm test
 ```
 
 This runs the test suite located in `__tests__/` covering the enhanced event bus, rate limiter and API endpoint logic.
+
+## Required Environment Variables
+
+Sensitive credentials can be loaded from environment variables or a `config.json` file placed in the project root. Define the following variables:
+
+- `OPENAI_API_KEY`
+- `RUNWAYML_API_KEY`
+- `OPENROUTER_API_KEY`
+- `ELEVENLABS_API_KEY`
+- `ELEVENLABS_VOICE_ID`
+- `GOOGLE_SHEETS_CREDENTIAL_ID`
+- `GOOGLE_SHEETS_ACCOUNT_NAME`
+- `YOUTUBE_CREDENTIAL_ID`
+- `YOUTUBE_ACCOUNT_NAME`

--- a/__tests__/eventBus.test.js
+++ b/__tests__/eventBus.test.js
@@ -1,0 +1,26 @@
+const { EnhancedEventBus } = require('../src/eventBus');
+
+describe('EnhancedEventBus', () => {
+  test('moves failing messages to dead letter and can reprocess', () => {
+    const bus = new EnhancedEventBus();
+    bus.maxRetries = 0;
+    bus.retryDelays = [0];
+
+    const failingHandler = () => { throw new Error('boom'); };
+    bus.subscribe('test', failingHandler);
+    bus.emit('test', { foo: 'bar' });
+
+    const messages = bus.getDeadLetterMessages();
+    expect(messages.length).toBe(1);
+    const id = messages[0].id;
+    expect(messages[0].type).toBe('test');
+
+    const successHandler = jest.fn();
+    bus.subscribe('test', successHandler);
+    const result = bus.reprocessDeadLetter(id);
+
+    expect(result).toBe(true);
+    expect(successHandler).toHaveBeenCalled();
+    expect(bus.getDeadLetterMessages().length).toBe(0);
+  });
+});

--- a/__tests__/processVideo.test.js
+++ b/__tests__/processVideo.test.js
@@ -1,0 +1,25 @@
+const request = require('supertest');
+
+// Set API key for the server before it is required
+process.env.API_KEY = 'test-key';
+
+const app = require('../src/app');
+
+describe('/process-video endpoint', () => {
+  test('returns correlationId for valid request', async () => {
+    const res = await request(app)
+      .post('/process-video')
+      .set('x-api-key', 'test-key')
+      .send({ promptParams: { topic: 'test' }, options: { priority: 'high', userId: 'u1' } });
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('correlationId');
+  });
+
+  test('returns 400 when request body is invalid', async () => {
+    const res = await request(app)
+      .post('/process-video')
+      .set('x-api-key', 'test-key')
+      .send({});
+    expect(res.status).toBe(400);
+  });
+});

--- a/__tests__/rateLimiter.test.js
+++ b/__tests__/rateLimiter.test.js
@@ -1,0 +1,20 @@
+const RateLimiter = require('../src/rateLimiter');
+
+describe('RateLimiter', () => {
+  test('throws when request limit exceeded', () => {
+    const rl = new RateLimiter(2, 1000, 1000, 10);
+    rl.checkLimit('user');
+    rl.checkLimit('user');
+    expect(() => rl.checkLimit('user')).toThrow('Rate limit exceeded');
+  });
+
+  test('cleanup removes old entries', () => {
+    jest.useFakeTimers();
+    const rl = new RateLimiter(2, 1000, 1000, 10);
+    rl.checkLimit('user');
+    jest.advanceTimersByTime(1500);
+    rl.cleanup();
+    expect(() => rl.checkLimit('user')).not.toThrow();
+    jest.useRealTimers();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "commonjs",
   "scripts": {
     "start": "node src/app.js",
-    "test": "echo \"No tests specified\" && exit 0"
+    "test": "jest"
   },
   "dependencies": {
     "express": "^4.18.2",
@@ -14,5 +14,9 @@
     "joi": "^17.9.2",
     "winston": "^3.9.0",
     "uuid": "^9.0.0"
+  },
+  "devDependencies": {
+    "jest": "^29.6.1",
+    "supertest": "^6.3.3"
   }
 }

--- a/src/app.js
+++ b/src/app.js
@@ -98,6 +98,11 @@ app.get('/', (req, res) => {
 });
 
 const PORT = process.env.PORT || 9001;
-app.listen(PORT, () => {
-  logger.info(`Server running at http://localhost:${PORT}`);
-});
+
+if (require.main === module) {
+  app.listen(PORT, () => {
+    logger.info(`Server running at http://localhost:${PORT}`);
+  });
+}
+
+module.exports = app;


### PR DESCRIPTION
## Summary
- add Jest and Supertest dev dependencies
- export `app` to allow running tests
- write tests for EventBus, RateLimiter and process-video endpoint
- document how to run the tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867506959c8832184f016b4ddd64a18